### PR TITLE
Migrate to the CryptoTokenKit persistant token API

### DIFF
--- a/SecureEnclaveToken.xcodeproj/project.pbxproj
+++ b/SecureEnclaveToken.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					BD60D38F25D58D6F0075CC34 = {
 						CreatedOnToolsVersion = 12.4;
@@ -352,7 +352,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -407,7 +407,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -438,7 +438,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mwielgoszewski.SecureEnclaveToken;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -468,7 +467,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mwielgoszewski.SecureEnclaveToken;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SecureEnclaveToken.xcodeproj/xcshareddata/xcschemes/SecureEnclaveToken.xcscheme
+++ b/SecureEnclaveToken.xcodeproj/xcshareddata/xcschemes/SecureEnclaveToken.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SecureEnclaveToken.xcodeproj/xcshareddata/xcschemes/SecureEnclaveTokenExtension.xcscheme
+++ b/SecureEnclaveToken.xcodeproj/xcshareddata/xcschemes/SecureEnclaveTokenExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/SecureEnclaveToken/ContentView.swift
+++ b/SecureEnclaveToken/ContentView.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
     }
 
     func unloadTokenConfig() {
-        driverConfig!.tokenConfigurations[tokenID]?.keychainItems.removeAll()
+        driverConfig!.removeTokenConfiguration(for: tokenID)
     }
 
     func clearAllTokenConfigs() {

--- a/SecureEnclaveTokenExtension/Token.swift
+++ b/SecureEnclaveTokenExtension/Token.swift
@@ -7,12 +7,12 @@
 
 import CryptoTokenKit
 
-class Token: TKSmartCardToken, TKTokenDelegate {
+class Token: TKToken, TKTokenDelegate {
 
-    init(smartCard: TKSmartCard, tokenDriver: TokenDriver, configuration: TKToken.Configuration) throws {
+    init(tokenDriver: TokenDriver, instanceID: TKToken.InstanceID) throws {
         NSLog("Initializing Token configuration based interface")
-        NSLog("Got instanceID: \(configuration.instanceID)")
-        super.init(smartCard: smartCard, aid: nil, instanceID: configuration.instanceID, tokenDriver: tokenDriver)
+        NSLog("Got instanceID: \(instanceID)")
+        super.init(tokenDriver: tokenDriver, instanceID: instanceID)
         self.keychainContents?.fill(with: configuration.keychainItems)
         do {
             let tag = "com.mwielgoszewski.SecureEnclaveToken.Key".data(using: .utf8)!
@@ -22,14 +22,6 @@ class Token: TKSmartCardToken, TKTokenDelegate {
             NSLog("Failed pulling certificate")
         }
         NSLog("Got keychain items: \(String(describing: self.keychainContents?.items.count))")
-    }
-
-    init(smartCard: TKSmartCard, aid AID: Data?, tokenDriver: TKSmartCardTokenDriver) throws {
-        let instanceID = "token_instance_id" // Fill in a unique persistent identifier of the token instance.
-        super.init(smartCard: smartCard, aid: AID, instanceID: instanceID, tokenDriver: tokenDriver)
-        // Insert code here to enumerate token objects and populate keychainContents with instances of TKTokenKeychainCertificate, TKTokenKeychainKey, etc.
-        let items = [TKTokenKeychainItem]()
-        self.keychainContents!.fill(with: items)
     }
 
     func createSession(_ token: TKToken) throws -> TKTokenSession {

--- a/SecureEnclaveTokenExtension/TokenDriver.swift
+++ b/SecureEnclaveTokenExtension/TokenDriver.swift
@@ -7,15 +7,10 @@
 
 import CryptoTokenKit
 
-class TokenDriver: TKSmartCardTokenDriver, TKSmartCardTokenDriverDelegate {
+class TokenDriver: TKTokenDriver, TKTokenDriverDelegate {
 
     func tokenDriver(_ driver: TKTokenDriver, tokenFor configuration: TKToken.Configuration) throws -> TKToken {
         NSLog("CTK/SecureEnclaveTokenExtension Initializing")
-        let smartCard = TKSmartCard()
-        return try Token(smartCard: smartCard, tokenDriver: self, configuration: configuration)
-    }
-
-    func tokenDriver(_ driver: TKSmartCardTokenDriver, createTokenFor smartCard: TKSmartCard, aid AID: Data?) throws -> TKSmartCardToken {
-        return try Token(smartCard: smartCard, aid: AID, tokenDriver: self)
+        return try Token(tokenDriver: self, instanceID: configuration.instanceID)
     }
 }

--- a/SecureEnclaveTokenExtension/TokenSession.swift
+++ b/SecureEnclaveTokenExtension/TokenSession.swift
@@ -7,7 +7,7 @@
 
 import CryptoTokenKit
 
-class TokenSession: TKSmartCardTokenSession, TKTokenSessionDelegate {
+class TokenSession: TKTokenSession, TKTokenSessionDelegate {
 
     func tokenSession(_ session: TKTokenSession, beginAuthFor operation: TKTokenOperation, constraint: Any) throws -> TKTokenAuthOperation {
         // Insert code here to create an instance of TKTokenAuthOperation based on the specified operation and constraint.
@@ -102,8 +102,8 @@ class TokenSession: TKSmartCardTokenSession, TKTokenSessionDelegate {
         throw NSError(domain: TKErrorDomain, code: TKError.Code.notImplemented.rawValue, userInfo: nil)
     }
 
-    func tokenSession(_ session: TKTokenSession, performKeyExchange otherPartyPublicKeyData: Data, keyObjectID objectID: Any, algorithm: TKTokenKeyAlgorithm, parameters: TKTokenKeyExchangeParameters) throws -> Data {
-
+    func tokenSession(_ session: TKTokenSession, performKeyExchange otherPartyPublicKeyData: Data, keyObjectID objectID: Any, algorithm: TKTokenKeyAlgorithm, parameters: TKTokenKeyExchangeParameters) throws ->
+    Data {
         let tag = String(data: objectID as! Data, encoding: .utf8)!
 
         NSLog("Querying for keyObjectID: \(tag) to perform key exchange")


### PR DESCRIPTION
The persistant token API is intended for tokens that don't require
insert/removal semantics such as the Secure Enclave. In macOS 10.15.5
Apple repaired this API and it became functional on macOS for the first
time.

https://support.apple.com/guide/deployment-reference-ios/about-persistent-tokens-apd05d8c6344/web
https://developer.apple.com/documentation/cryptotokenkit